### PR TITLE
fix to support reconfiguration of port.

### DIFF
--- a/src/hcl/hcl_internal.cpp
+++ b/src/hcl/hcl_internal.cpp
@@ -84,7 +84,8 @@ int HCL::ConfigureInternal(bool initialize, uint16_t _port,
     throw new std::logic_error(
         "To change the server list or URI use a new port");
   }
-  if (initialize || _server_list_path.size() != 0 || _uri.size() != 0) {
+  if (initialize || _server_list_path.size() != 0 || _uri.size() != 0 ||
+      previous_port != conf->RPC_PORT) {
     auto uris = LoadURI(conf->RPC_PORT, conf->SERVER_LIST_PATH, conf->URI,
                         conf->MY_SERVER, conf->IS_SERVER);
     if (uris.size() != conf->NUM_SERVERS) {


### PR DESCRIPTION
Fix to support reconfiguration.
The below test produces the error.
Set the env variable SERVER_LIST_PATH to where the file server list is. 

```
/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 * Distributed under BSD 3-Clause license.                                   *
 * Copyright by The HDF Group.                                               *
 * Copyright by the Illinois Institute of Technology.                        *
 * All rights reserved.                                                      *
 *                                                                           *
 * This file is part of Hermes. The full Hermes copyright notice, including  *
 * terms governing use, modification, and redistribution, is contained in    *
 * the COPYING file, which can be found at the top directory. If you do not  *
 * have access to the file, you may request a copy from help@hdfgroup.org.   *
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

#include <execinfo.h>
#include <hcl.h>
#include <hcl/common/data_structures.h>
#include <hcl/unordered_map/unordered_map.h>
#include <mpi.h>
#include <signal.h>
#include <sys/types.h>
#include <unistd.h>

#include <chrono>
#include <functional>
#include <iostream>
#include <map>
#include <utility>

struct KeyType {
  size_t a;
  KeyType() : a(0) {}
  KeyType(size_t a_) : a(a_) {}
  /* equal operator for comparing two Matrix. */
  bool operator==(const KeyType &o) const { return a == o.a; }
  KeyType &operator=(const KeyType &other) {
    a = other.a;
    return *this;
  }
  bool operator<(const KeyType &o) const { return a < o.a; }
  bool operator>(const KeyType &o) const { return a > o.a; }
  bool Contains(const KeyType &o) const { return a == o.a; }
};
template <typename A>
void serialize(A &ar, KeyType &a) {
  ar &a.a;
}
namespace std {
template <>
struct hash<KeyType> {
  size_t operator()(const KeyType &k) const { return k.a; }
};
}  // namespace std

int main(int argc, char *argv[]) {
  int provided;
  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
  if (provided < MPI_THREAD_MULTIPLE) {
    printf("Didn't receive appropriate MPI threading specification\n");
    exit(EXIT_FAILURE);
  }
  int comm_size, my_rank;
  MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
  MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
  int ranks_per_server = comm_size, num_request = 100;
  long size_of_request = 1024;
  bool debug = false;
  bool server_on_node = false;

  /* if(comm_size/ranks_per_server < 2){
       perror("comm_size/ranks_per_server should be atleast 2 for this test\n");
       exit(-1);
   }*/
  int len;
  char processor_name[MPI_MAX_PROCESSOR_NAME];
  MPI_Get_processor_name(processor_name, &len);
  if (debug) {
    printf("%s/%d: %d\n", processor_name, my_rank, getpid());
  }

  char *server_list_path = std::getenv("SERVER_LIST_PATH");
  if (debug && my_rank == 0) {
    printf("%d ready for attach\n", comm_size);
    fflush(stdout);
    getchar();
  }
  MPI_Barrier(MPI_COMM_WORLD);
  bool is_server = (my_rank == 0) || (my_rank == 1);
  int my_server = 0;
  int num_servers = 1;

  // The following is used to switch to 40g network on Ares.
  // This is necessary when we use RoCE on Ares.
  std::string proc_name = std::string(processor_name);
  /*int split_loc = proc_name.find('.');
  std::string node_name = proc_name.substr(0, split_loc);
  std::string extra_info = proc_name.substr(split_loc+1, string::npos);
  proc_name = node_name + "-40g." + extra_info;*/

  std::string my_vals(size_of_request, 'x');

  HCL_CONF->IS_SERVER = is_server;
  HCL_CONF->MY_SERVER = 0;  // my_rank == 1 ? 1 : my_server;
  HCL_CONF->NUM_SERVERS = num_servers;
  HCL_CONF->SERVER_ON_NODE = server_on_node || is_server;
  HCL_CONF->SERVER_LIST_PATH = std::string(server_list_path) + "server_list";

  std::shared_ptr<hcl::HCL> hcl;

  typedef boost::interprocess::allocator<
      char, boost::interprocess::managed_mapped_file::segment_manager>
      CharAllocator;
  typedef bip::basic_string<char, std::char_traits<char>, CharAllocator>
      MappedUnitString;

  hcl::unordered_map<KeyType, std::string, std::hash<KeyType>, CharAllocator,
                     MappedUnitString> *map1;
  // hcl::unordered_map<KeyType, std::string, std::hash<KeyType>, CharAllocator,
  //                    MappedUnitString> *map2;
  hcl::queue<KeyType> *q;

  if (my_rank == 0) {
    hcl = hcl::HCL::GetInstance(true, 9000);
    map1 = new hcl::unordered_map<KeyType, std::string, std::hash<KeyType>,
                                  CharAllocator, MappedUnitString>("map1");
  }
  if (my_rank == 1) {
    hcl = hcl::HCL::GetInstance(true, 10000);
    q = new hcl::queue<KeyType>();
  }
  MPI_Barrier(MPI_COMM_WORLD);
  if (!is_server) {
    hcl = hcl::HCL::GetInstance(true, 9000);
    map1 = new hcl::unordered_map<KeyType, std::string, std::hash<KeyType>,
                                  CharAllocator, MappedUnitString>("map1");

    // HCL_CONF->MY_SERVER = 1;
    // HCL_CONF->NUM_SERVERS = num_servers;
    // hcl = hcl::HCL::GetInstance(false);
    hcl->ReConfigure(10000);
    q = new hcl::queue<KeyType>();
  }

  MPI_Barrier(MPI_COMM_WORLD);

  if (my_rank == 2) {
    /*Local map test*/
    for (int i = 0; i < num_request; i++) {
      size_t val = my_server;
      auto key = KeyType(val);
      auto result = map1->Put(key, my_vals);
      assert(result);
    }
  }
  MPI_Barrier(MPI_COMM_WORLD);

  if (my_rank == 3) {
    /*Local map test*/
    for (int i = 0; i < num_request; i++) {
      size_t val = my_server;
      auto key = KeyType(val);
      auto result = map1->Get(key);
      assert(result.first);
      assert(result.second.size() == size_of_request);
      assert(result.second[0] == 'x');
    }
  }

  if (my_rank == 3) {
    uint16_t key = 0;
    q->Size(key);
  }

  MPI_Barrier(MPI_COMM_WORLD);
  hcl->Finalize();
  MPI_Finalize();
  exit(EXIT_SUCCESS);
}

```