### PR TITLE
Update documents to describe the value size limitation within Boost

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -54,7 +54,7 @@ SERVER_LIST_PATH                 STRING  List of servers defined for HCL. The fo
 BACKED_FILE_DIR                  STRING  Where to store the file backed file. Default is /dev/shm. Can be stored on ssd as well.
 ================================ ======  ===========================================================================
 
-Configuration variables for using environment varibles
+Configuration variables for using environment variables
 *********************************************************
 ================================ ======  ===========================================================================
 Configuration Option             Type    Description

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ HCL: a distributed data structure library with STL like interface
    overview
    build
    api
+   limitations
 
 .. toctree::
    :maxdepth: 2

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -1,0 +1,17 @@
+=============
+Limitations
+=============
+
+Character arrays have a stack-size limit, this is system-dependent, but typically 1-2 MiB. You can make custom CharStructs with character arrays that store a lot of data, but never more than stack size.
+
+In order to alleviate this, the intended solution in HCL is to utilize boost shared memory stack allocation. See example:
+
+.. code-block:: cpp
+
+    typedef boost::interprocess::allocator<char, boost::interprocess::managed_mapped_file::segment_manager> CharAllocator;
+    typedef bip::basic_string<char, std::char_traits<char>, CharAllocator> MappedUnitString;
+    hcl::unordered_map<struct KeyType, std::string, std::hash<KeyType>, CharAllocator, MappedUnitString> *hcl_string_client;
+
+
+However, boost shared memory allocators also have limitations. The limitation is nearly 128 MiB, you can push to 127.9 MiB, but not all the way up to 128 (more detail at `issue 22
+<https://github.com/hariharan-devarajan/hcl/issues/22>`_). We recommend not going over 64 MiB for boost shared memory strings, and also note that performance with this allocation is far more variable than stack allocation.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -28,7 +28,7 @@ Supported Data structors with server-specific distribution
 #. hcl::vector
 
 --------------------------
-Experimenal data structures
+Experimental data structures
 --------------------------
 
 #. hcl::concurrent_skiplist


### PR DESCRIPTION
This PR adds the limitation on data size to documents, as seen with boost allocators, which limit allocation to 128 MiB. 
Also, fixes a few other typos.